### PR TITLE
Fix compile with MinGW

### DIFF
--- a/src/city.cc
+++ b/src/city.cc
@@ -47,7 +47,7 @@ static uint32 UNALIGNED_LOAD32(const char *p) {
   return result;
 }
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 
 #include <stdlib.h>
 #define bswap_32(x) _byteswap_ulong(x)


### PR DESCRIPTION
When compiling for Windows with MinGW rather than Visual Studio, the `byteswap.h` header isn't found. To fix this I've broadened the check on `_MSC_VER` to `_WIN32` so that it covers Windows regardless of the compiler used.

See https://github.com/mapeditor/qaseprite/pull/7.